### PR TITLE
Bump pydocstyle 6.2.3 -> 6.3.0 and pyright 1.1.289 -> 1.1.290

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -255,7 +255,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade wheel
-          python -m pip install pydocstyle==6.2.3
+          python -m pip install pydocstyle==6.3.0
       - run: >-
           pydocstyle --verbose --explain ${{
           steps.changed-files.outputs.all_changed_files }}
@@ -324,7 +324,7 @@ jobs:
           python -m pip install -r requirements.txt
       - uses: jakebailey/pyright-action@v1
         with:
-          version: 1.1.289
+          version: 1.1.290
           project: pyrightconf.json
           extra-args: ${{ steps.changed-files.outputs.all_changed_files }}
         if: steps.changed-files.outputs.all_changed_files != ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
           - aiohttp[speedups]
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.2.3
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
 
@@ -107,7 +107,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.289
+    rev: v1.1.290
     hooks:
       - id: pyright
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,8 +5,8 @@
 pylint==2.15.10
 flake8==4.0.1
 bandit==1.7.4
-pyright==1.1.289
-pydocstyle==6.2.3
+pyright==1.1.290
+pydocstyle==6.3.0
 
 # Formatting
 black==22.12.0


### PR DESCRIPTION
Bump dependencies in dev-requirements.txt, pre-commit and CI.