### PR TITLE
Fix pyright on CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -317,17 +317,16 @@ jobs:
           python-version: "3.11"
       # pyrightconf.json expects a virtual environment in .venv
       - run: |
+          python -m pip install pyright==1.1.290
           python -m venv .venv
           source .venv/bin/activate
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade wheel
           python -m pip install -r requirements.txt
-      - uses: jakebailey/pyright-action@v1
-        with:
-          version: 1.1.290
-          project: pyrightconf.json
-          extra-args: ${{ steps.changed-files.outputs.all_changed_files }}
+      - run: >-
+          pyright --verbose --stats --warnings ${{
+          steps.changed-files.outputs.all_changed_files }}
         if: steps.changed-files.outputs.all_changed_files != ''
 
   skjold:


### PR DESCRIPTION
The github action seems to cd into udemy-autocoupons before running. Pyright can't then find pyrightconfig.json.

Pyright is now installed through pypi globally (this fixes #5) and ran via CLI, which fixes the problem.