### PR TITLE
Check for cursor to be allowed in checkout

### DIFF
--- a/udemy_autocoupons/enroller/udemy_driver.py
+++ b/udemy_autocoupons/enroller/udemy_driver.py
@@ -121,10 +121,18 @@ class UdemyDriver:
             )
             return state
 
-        checkout_button = self._wait_for_clickable(
-            '[class*="checkout-button--checkout-button--button"]',
+        checkout_button_selector = (
+            '[class*="checkout-button--checkout-button--button"]'
         )
-        checkout_button.click()
+
+        self._wait.until(
+            EC.all_of(
+                self._ec_clickable(checkout_button_selector),
+                self._ec_cursor_allowed(checkout_button_selector),
+            ),
+        )
+
+        self._find(checkout_button_selector).click()
 
         self._wait.until(lambda driver: "checkout" not in driver.current_url)
         return State.ENROLLED

--- a/udemy_autocoupons/enroller/udemy_driver.py
+++ b/udemy_autocoupons/enroller/udemy_driver.py
@@ -26,6 +26,8 @@ _debug = getLogger("debug")
 
 _CheckedStateT = Literal[State.PAID, State.TO_BLACKLIST, State.ENROLLABLE]
 
+_ExpectedConditionT = Callable[[Chrome], WebElement | Literal[False]]
+
 
 class UdemyDriver:
     """Handles Udemy usage.
@@ -315,9 +317,7 @@ class UdemyDriver:
             The element once it's clickable.
 
         """
-        return self._wait.until(
-            EC.element_to_be_clickable((By.CSS_SELECTOR, css_selector)),
-        )
+        return self._wait.until(self._ec_clickable(css_selector))
 
     def _find(self, css_selector: str) -> WebElement:
         """Finds without waiting the element with the given CSS selector.
@@ -347,7 +347,7 @@ class UdemyDriver:
         return self.driver.find_elements(By.CSS_SELECTOR, css_selector)
 
     @staticmethod
-    def _ec_located(css_selector: str) -> Callable[[Chrome], WebElement]:
+    def _ec_located(css_selector: str) -> _ExpectedConditionT:
         """Creates an expected condition for locating the given selector.
 
         Args:
@@ -358,3 +358,16 @@ class UdemyDriver:
 
         """
         return EC.presence_of_element_located((By.CSS_SELECTOR, css_selector))
+
+    @staticmethod
+    def _ec_clickable(css_selector: str) -> _ExpectedConditionT:
+        """Creates an expected condition for the given selector to be clickable.
+
+        Args:
+            css_selector: The CSS selector of the element.
+
+        Returns:
+            An expected condition which returns the found element.
+
+        """
+        return EC.element_to_be_clickable((By.CSS_SELECTOR, css_selector))

--- a/udemy_autocoupons/enroller/udemy_driver.py
+++ b/udemy_autocoupons/enroller/udemy_driver.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from functools import partial
 from logging import getLogger
 from typing import Literal
 
@@ -371,3 +372,35 @@ class UdemyDriver:
 
         """
         return EC.element_to_be_clickable((By.CSS_SELECTOR, css_selector))
+
+    @staticmethod
+    def _cursor_to_be_allowed(
+        css_selector: str,
+        driver: Chrome,
+    ) -> WebElement | Literal[False]:
+        """An expected condition for the cursor to be allowed.
+
+        Args:
+            css_selector: The CSS selector of the element.
+            driver: The Chrome WebDriver to use.
+
+        """
+        target = driver.find_element(By.CSS_SELECTOR, css_selector)
+
+        if target.value_of_css_property("cursor") != "not-allowed":
+            return target
+
+        return False
+
+    @classmethod
+    def _ec_cursor_allowed(cls, css_selector: str) -> _ExpectedConditionT:
+        """Creates an expected condition for the cursor to be allowed.
+
+        Args:
+            css_selector: The CSS selector of the element.
+
+        Returns:
+            An expected condition which returns the found element.
+
+        """
+        return partial(cls._cursor_to_be_allowed, css_selector)


### PR DESCRIPTION
Checks for the cursor css property not to be "not-allowed" on the checkout button. This should help avoid error, reducing retries and enroll time. 