### PR TITLE
Add UTF-8 encoding to log file

### DIFF
--- a/udemy_autocoupons/loggers.py
+++ b/udemy_autocoupons/loggers.py
@@ -23,7 +23,7 @@ def setup_loggers() -> None:
         "%H:%M:%S",
     )
 
-    debug_handler = FileHandler("log.log")
+    debug_handler = FileHandler("log.log", encoding="utf-8")
     debug = create_logger(
         "debug",
         DEBUG,


### PR DESCRIPTION
- This prevents crashes when logging UTF-8 URLs